### PR TITLE
docs: update link to angular demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@ section img {
         </h2>
         <div class="center" id="demos">
             <a class="demo-link" rel="noopener" target="_blank" href="https://movies.zaps.dev">Demo - Next.js</a>
-            <a class="demo-link" rel="noopener" target="_blank" href="https://angular-movies-a12d3.web.app/movies/popular">Demo - Angular</a>
+            <a class="demo-link" rel="noopener" target="_blank" href="https://angular-movies-a12d3.web.app">Demo - Angular</a>
             <a class="demo-link" rel="noopener" target="_blank" href="https://nuxt-movies.vercel.app">Demo - Nuxt.js</a>
             <p class="additional">You may also be interested in additional TMDB apps using <a href="https://github.com/tastejs/sveltekit-movie-app">SvelteKit</a> (<a href="https://sveltekit-movies.netlify.app">Demo</a>) or <a href="https://github.com/tastejs/lit-movies">Lit</a> (<a href="https://lit-movies.netlify.app">Demo</a>)</p>
         </div>


### PR DESCRIPTION
Removed deep-link, and point to index directly